### PR TITLE
Add Dockerfile for FastAPI backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV LSM_BASE=/app
+
+COPY . /app
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "lsm_hand_tracker.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ The project is currently in the **experimental phase**, focusing on setting up t
      LSM_BASE=<path_to_project_directory>
      ```
 
+### Docker Deployment
+Build the backend API into a container and expose it on port 8000:
+```bash
+docker build -t lsm-hand-tracker .
+docker run -p 8000:8000 lsm-hand-tracker
+```
+The service will be available at `http://localhost:8000`.
+
 ---
 
 ## Usage


### PR DESCRIPTION
## Summary
- containerize backend with Dockerfile
- document Docker deployment in README

## Testing
- `pytest -q` *(fails: test_code_is_tested)*

------
https://chatgpt.com/codex/tasks/task_e_684e3d3fe2a0832e9c622e399f5ec1f4